### PR TITLE
Added more ImGui widgets, some parameter refactors

### DIFF
--- a/Source/ImGuiBlueprint/Private/K2Node_TabBarMenu.cpp
+++ b/Source/ImGuiBlueprint/Private/K2Node_TabBarMenu.cpp
@@ -1,0 +1,35 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "K2Node_TabBarMenu.h"
+
+UK2Node_TabBarMenu* UK2Node_TabBarMenu::ImGui_TabBarMenu(TArray<FString> Tabs)
+{
+	UK2Node_TabBarMenu* NewAsyncObject = NewObject<UK2Node_TabBarMenu>();
+	NewAsyncObject->TabNames = Tabs;
+	return NewAsyncObject;
+}
+
+void UK2Node_TabBarMenu::Activate()
+{
+	Super::Activate();
+	
+	// Passing a bool* to BeginTabItem() is similar to passing one to Begin():
+	// the underlying bool will be set to false when the tab is closed.
+	if (ImGui::BeginTabBar("MyTabBar"))
+	{
+		for (int n = 0; n < TabNames.Num(); n++)
+		{
+			if (ImGui::BeginTabItem(TCHAR_TO_UTF8(*TabNames[n])))
+			{
+				TabAdded.Broadcast(n);
+				ImGui::EndTabItem();
+			}
+		}
+			
+		ImGui::EndTabBar();
+	}
+
+	Finish.Broadcast();
+	RemoveFromRoot();
+}

--- a/Source/ImGuiBlueprint/Private/K2Node_Table.cpp
+++ b/Source/ImGuiBlueprint/Private/K2Node_Table.cpp
@@ -1,0 +1,52 @@
+﻿// Copyright (C) Varian Daemon 2023. All Rights Reserved.
+
+
+#include "K2Node_Table.h"
+
+#include "imgui.h"
+
+UK2Node_Table* UK2Node_Table::ImGui_Table(TArray<FString> Columns, int32 RowAmount, FVector2D Size)
+{
+	UK2Node_Table* NewAsyncObject = NewObject<UK2Node_Table>();
+	NewAsyncObject->ColumnNames = Columns;
+	NewAsyncObject->RowAmounts = RowAmount;
+	NewAsyncObject->TableSize = Size;
+	return NewAsyncObject;
+}
+
+void UK2Node_Table::Activate()
+{
+	Super::Activate();
+	ImGuiTableFlags flags =
+		   ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable | ImGuiTableFlags_SortMulti
+		   | ImGuiTableFlags_RowBg | ImGuiTableFlags_Borders | ImGuiTableFlags_NoBordersInBody
+		   | ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY
+		   | ImGuiTableFlags_SizingFixedFit;
+	
+	if(ImGui::BeginTable("table advanced", ColumnNames.Num(), flags, ImVec2(TableSize.X, TableSize.Y)))
+	{
+		//Create the columns
+		for(auto& CurrentColumn : ColumnNames)
+		{
+			ImGui::TableSetupColumn(TCHAR_TO_UTF8(*CurrentColumn), ImGuiTableColumnFlags_WidthStretch);
+		}
+
+		//You have to create columns first, then call this
+		ImGui::TableHeadersRow();
+
+		//Start creating the rows
+		for(int32 RowIndex = 0; RowIndex < RowAmounts; RowIndex++)
+		{
+			ImGui::TableNextRow();
+			//Iterate over all the columns and start filling them.
+			for(int32 ColumnIndex = 0; ColumnIndex < ColumnNames.Num(); ColumnIndex++)
+			{
+				
+				ImGui::TableSetColumnIndex(ColumnIndex);
+				RowCreated.Broadcast(ColumnIndex, RowIndex);
+			}
+		}
+		
+		ImGui::EndTable();
+	}
+}

--- a/Source/ImGuiBlueprint/Private/K2Node_TreeNode.cpp
+++ b/Source/ImGuiBlueprint/Private/K2Node_TreeNode.cpp
@@ -1,0 +1,24 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "K2Node_TreeNode.h"
+
+UK2Node_TreeNode* UK2Node_TreeNode::ImGui_TreeNode(FString Label)
+{
+	UK2Node_TreeNode* NewAsyncObject = NewObject<UK2Node_TreeNode>();
+	NewAsyncObject->TreeLabel = Label;
+	return NewAsyncObject;
+}
+
+void UK2Node_TreeNode::Activate()
+{
+	Super::Activate();
+	if(ImGui::TreeNode(TCHAR_TO_UTF8(*TreeLabel)))
+	{
+		TreeCreated.Broadcast();
+		ImGui::TreePop();
+	}
+	Finish.Broadcast();
+	RemoveFromRoot();
+}
+

--- a/Source/ImGuiBlueprint/Public/ImGuiBlueprintLibrary.h
+++ b/Source/ImGuiBlueprint/Public/ImGuiBlueprintLibrary.h
@@ -4,6 +4,7 @@
 
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "imgui.h"
+#include "Kismet/KismetMathLibrary.h"
 #include "ImGuiBlueprintLibrary.generated.h"
 
 /* 
@@ -46,7 +47,7 @@ public:
 	static void ImGui_Text(FText Text, FLinearColor Color = FLinearColor(1.0f,1.0f,1.0f))
 	{
 		const FColor SRGB = Color.ToFColorSRGB();
-		ImGui::TextColored(ImVec4(SRGB.R/255.f, SRGB.G/255.f, SRGB.B/255.f, SRGB.A/255.f), "%s", TCHAR_TO_UTF8(*Text.ToString()));
+		ImGui::TextColored(ImVec4(SRGB.R/255.f, SRGB.G/255.f, SRGB.B/255.f, SRGB.A/255.f), "%s", TCHAR_TO_UTF8(*Text));
 	}
 
 	UFUNCTION(BlueprintCallable, Category="ImGui|Basic", meta=(AdvancedDisplay=1), BlueprintInternalUseOnly)
@@ -59,6 +60,70 @@ public:
 	static void ImGui_SameLine(float OffsetFromStartX, float Spacing = -1)
 	{
 		ImGui::SameLine(OffsetFromStartX, Spacing);
+	}
+
+	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
+	static bool ImGui_Slider(FString Text, float Min, float Max, float& Value)
+	{
+		static float SliderValue = 0;
+		bool Success = ImGui::SliderFloat(TCHAR_TO_UTF8(*Text), &SliderValue, Min, Max);
+		Value = SliderValue;
+		return Success;
+	}
+
+	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
+	static bool ImGui_VSlider(FString Text, float Min, float Max, FVector2D Size, float& Value)
+	{
+		static float SliderValue = 0;
+		bool Success = ImGui::VSliderFloat(TCHAR_TO_UTF8(*Text), ImVec2(Size.X, Size.Y), &SliderValue, Min, Max);
+		Value = SliderValue;
+		return Success;
+	}
+
+	//If @Text is empty, it'll display the percentage
+	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
+	static void ImGui_ProgressBar(float Progress, float Min, float Max, FVector2D Size, FString Text)
+	{
+		float NewProgress =	UKismetMathLibrary::MapRangeClamped(Progress, Min, Max, 0, 1);
+		if(Text.IsEmpty())
+		{
+			ImGui::ProgressBar(NewProgress, ImVec2(Size.X, Size.Y));
+		}
+		else
+		{
+			ImGui::ProgressBar(NewProgress, ImVec2(Size.X, Size.Y), TCHAR_TO_UTF8(*Text));
+		}
+	}
+
+	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
+	static void ImGui_PlotLines(FString Text, TArray<float> Floats, FVector2D Size, float Min, float Max)
+	{
+		//Figure out the average, min and max.
+		//We have to pass min and max if we want to pass in custom size.
+		float Average = 0;
+		for(auto& CurrentFloat : Floats)
+		{
+			Average += CurrentFloat;
+		}
+		Average = Average/Floats.Num();
+		
+		ImGui::PlotLines(TCHAR_TO_UTF8(*Text), Floats.GetData(), Floats.Num(), 0,
+			TCHAR_TO_UTF8(*FString::SanitizeFloat(Average)), Min, Max, ImVec2(Size.X, Size.Y));
+	}
+
+	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
+	static bool ImGui_Checkbox(FString Text, UPARAM(ref) bool& BoolToUpdate)
+	{
+		static bool Value;
+		bool Pressed =  ImGui::Checkbox(TCHAR_TO_UTF8(*Text), &Value);
+		BoolToUpdate = Value;
+		return Pressed;
+	}
+
+	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
+	static void ImGui_Separator()
+	{
+		ImGui::Separator();
 	}
 
 	// Widgets: Menus

--- a/Source/ImGuiBlueprint/Public/ImGuiBlueprintLibrary.h
+++ b/Source/ImGuiBlueprint/Public/ImGuiBlueprintLibrary.h
@@ -44,16 +44,16 @@ public:
 	}
 
 	UFUNCTION(BlueprintCallable, Category="ImGui|Basic", meta=(AdvancedDisplay=1))
-	static void ImGui_Text(FText Text, FLinearColor Color = FLinearColor(1.0f,1.0f,1.0f))
+	static void ImGui_Text(FString Text, FLinearColor Color = FLinearColor(1.0f,1.0f,1.0f))
 	{
 		const FColor SRGB = Color.ToFColorSRGB();
 		ImGui::TextColored(ImVec4(SRGB.R/255.f, SRGB.G/255.f, SRGB.B/255.f, SRGB.A/255.f), "%s", TCHAR_TO_UTF8(*Text));
 	}
 
 	UFUNCTION(BlueprintCallable, Category="ImGui|Basic", meta=(AdvancedDisplay=1), BlueprintInternalUseOnly)
-	static bool ImGui_Button(FText Name, FVector2D Size)
+	static bool ImGui_Button(FString Text, FVector2D Size)
 	{
-		return ImGui::Button(TCHAR_TO_UTF8(*Name.ToString()), ImVec2(static_cast<float>(Size.X), static_cast<float>(Size.Y)));
+		return ImGui::Button(TCHAR_TO_UTF8(*Text), ImVec2(static_cast<float>(Size.X), static_cast<float>(Size.Y)));
 	}
 
 	UFUNCTION(BlueprintCallable, Category="ImGui|Basic", meta=(AdvancedDisplay="OffsetFromStartX,Spacing"))
@@ -158,8 +158,8 @@ public:
 
 	// NOTE: Shortcuts are not processed by Dear ImGui automatically
 	UFUNCTION(BlueprintCallable, Category="ImGui|Menus")
-	static bool ImGui_MenuItem(FText Label, FString Shortcut, bool Selected = false, bool Enabled = true)
+	static bool ImGui_MenuItem(FString Text, FString Shortcut, bool Selected = false, bool Enabled = true)
 	{
-		return ImGui::MenuItem(TCHAR_TO_UTF8(*Label.ToString()), TCHAR_TO_UTF8(*Shortcut), Selected, Enabled);
+		return ImGui::MenuItem(TCHAR_TO_UTF8(*Text), TCHAR_TO_UTF8(*Shortcut), Selected, Enabled);
 	}
 };

--- a/Source/ImGuiBlueprint/Public/ImGuiBlueprintLibrary.h
+++ b/Source/ImGuiBlueprint/Public/ImGuiBlueprintLibrary.h
@@ -63,21 +63,25 @@ public:
 	}
 
 	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
-	static bool ImGui_Slider(FString Text, float Min, float Max, float& Value)
+	static bool ImGui_Slider(FString Text, float Min, float Max, UPARAM(ref) float& Value)
 	{
-		static float SliderValue = 0;
-		bool Success = ImGui::SliderFloat(TCHAR_TO_UTF8(*Text), &SliderValue, Min, Max);
-		Value = SliderValue;
-		return Success;
+		bool Pressed = false;
+		if(ImGui::SliderFloat(TCHAR_TO_UTF8(*Text), &Value, Min, Max))
+		{
+			Pressed = true;
+		}
+		return Pressed;
 	}
 
 	UFUNCTION(BlueprintCallable, Category="ImGui|Basic")
-	static bool ImGui_VSlider(FString Text, float Min, float Max, FVector2D Size, float& Value)
+	static bool ImGui_VSlider(FString Text, float Min, float Max, FVector2D Size, UPARAM(ref) float& Value)
 	{
-		static float SliderValue = 0;
-		bool Success = ImGui::VSliderFloat(TCHAR_TO_UTF8(*Text), ImVec2(Size.X, Size.Y), &SliderValue, Min, Max);
-		Value = SliderValue;
-		return Success;
+		bool Pressed = false;
+		if(ImGui::VSliderFloat(TCHAR_TO_UTF8(*Text), ImVec2(Size.X, Size.Y), &Value, Min, Max))
+		{
+			Pressed = true;
+		}
+		return Pressed;
 	}
 
 	//If @Text is empty, it'll display the percentage

--- a/Source/ImGuiBlueprint/Public/K2Node_TabBarMenu.h
+++ b/Source/ImGuiBlueprint/Public/K2Node_TabBarMenu.h
@@ -1,0 +1,33 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "imgui.h"
+#include "K2Node_TabBarMenu.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FTabAdded, int32, TabIndex);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FFinish);
+
+UCLASS()
+class IMGUIBLUEPRINT_API UK2Node_TabBarMenu : public UBlueprintAsyncActionBase
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintAssignable)
+	FTabAdded TabAdded;
+
+	UPROPERTY(BlueprintAssignable)
+	FFinish Finish;
+
+	UPROPERTY()
+	TArray<FString> TabNames;
+
+public:
+
+	UFUNCTION(Category="ImGui|Menus", BlueprintCallable, meta=(BlueprintInternalUseOnly="true"))
+	static UK2Node_TabBarMenu* ImGui_TabBarMenu(TArray<FString> Tabs);
+
+	virtual void Activate() override;
+};

--- a/Source/ImGuiBlueprint/Public/K2Node_Table.h
+++ b/Source/ImGuiBlueprint/Public/K2Node_Table.h
@@ -1,0 +1,38 @@
+﻿// Copyright (C) Varian Daemon 2023. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "K2Node_Table.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FRowCreated, int32, ColumnIndex, int32, RowIndex);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FTableFinished);
+
+UCLASS()
+class IMGUIBLUEPRINT_API UK2Node_Table : public UBlueprintAsyncActionBase
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintAssignable)
+	FRowCreated RowCreated;
+	
+	UPROPERTY(BlueprintAssignable)
+	FTableFinished TableFinished;
+
+	UPROPERTY()
+	TArray<FString> ColumnNames;
+
+	UPROPERTY()
+	int32 RowAmounts;
+
+	UPROPERTY()
+	FVector2D TableSize;
+
+public:
+
+	UFUNCTION(Category="ImGui|Menus", BlueprintCallable, meta=(BlueprintInternalUseOnly="true"))
+	static UK2Node_Table* ImGui_Table(TArray<FString> Columns, int32 RowAmount, FVector2D Size);
+
+	virtual void Activate() override;
+};

--- a/Source/ImGuiBlueprint/Public/K2Node_TreeNode.h
+++ b/Source/ImGuiBlueprint/Public/K2Node_TreeNode.h
@@ -1,0 +1,33 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "imgui.h"
+#include "K2Node_TreeNode.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FTreeCreated);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FTreeFinished);
+
+UCLASS()
+class IMGUIBLUEPRINT_API UK2Node_TreeNode : public UBlueprintAsyncActionBase
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintAssignable)
+	FTreeCreated TreeCreated;
+	
+	UPROPERTY(BlueprintAssignable)
+	FTreeFinished Finish;
+
+	UPROPERTY()
+	FString TreeLabel;
+
+public:
+
+	UFUNCTION(Category="ImGui|Menus", BlueprintCallable, meta=(BlueprintInternalUseOnly="true"))
+	static UK2Node_TreeNode* ImGui_TreeNode(FString Label);
+
+	virtual void Activate() override;
+};

--- a/Source/ImGuiBlueprintUncookedOnly/Private/K2Node_ImGuiButton.cpp
+++ b/Source/ImGuiBlueprintUncookedOnly/Private/K2Node_ImGuiButton.cpp
@@ -25,7 +25,7 @@
 #define LOCTEXT_NAMESPACE "UK2Node_ImGuiButton"
 
 const FName UK2Node_ImGuiButton::OnClickExecutionPinName(TEXT("OnClickPin"));
-const FName UK2Node_ImGuiButton::NamePinName(TEXT("NamePin"));
+const FName UK2Node_ImGuiButton::NamePinName(TEXT("Text"));
 const FName UK2Node_ImGuiButton::SizePinName(TEXT("SizePin"));
 
 void UK2Node_ImGuiButton::GetMenuActions(FBlueprintActionDatabaseRegistrar& ActionRegistrar) const
@@ -46,7 +46,7 @@ void UK2Node_ImGuiButton::AllocateDefaultPins()
 	CreatePin(EGPD_Input, UEdGraphSchema_K2::PC_Exec, UEdGraphSchema_K2::PN_Execute);
 
 	// Button Name pin
-	const auto NamePin = CreatePin(EGPD_Input, UEdGraphSchema_K2::PC_Text, NamePinName);
+	const auto NamePin = CreatePin(EGPD_Input, UEdGraphSchema_K2::PC_String, NamePinName);
 	NamePin->PinType.bIsConst = true;
 	NamePin->DefaultTextValue = FText::AsCultureInvariant("");
 
@@ -85,7 +85,7 @@ void UK2Node_ImGuiButton::ExpandNode(FKismetCompilerContext& CompilerContext, UE
 	Button->FunctionReference.SetExternalMember(GET_FUNCTION_NAME_CHECKED(UImGuiBlueprintLibrary, ImGui_Button), UImGuiBlueprintLibrary::StaticClass());
 	Button->AllocateDefaultPins();
 
-	const auto FuncNamePin = Button->FindPinChecked(TEXT("Name"));
+	const auto FuncNamePin = Button->FindPinChecked(TEXT("Text"));
 	const auto FuncSizePin = Button->FindPinChecked(TEXT("Size"));
 	const auto FuncReturnValuePin = Button->GetReturnValuePin();
 


### PR DESCRIPTION
Nodes added:

- Tab bar
- Tree node
- Slider and vertical slider
- Plot lines
- Checkbox
- Separator
- Table
---
Refactored some parameters to always be FString, it seemed like it was ALWAYS being converted to FString, so it makes more sense to always have it be FString, also cleans up Blueprint code as there's fewer conversions in most cases.

I feel like the word "Label" isn't very consistent with how Unreal often describe their UI, I'm new to ImGui, soI thought "Label" was a way to retrieve the widget at a later date or something. The word "Text" is often used in Unreal to describe the text inside a widget, so it seems like it is more suitable, but at the same time it is inconsistent with the naming scheme for ImGui, so I'm torn whether it makes more sense or not.